### PR TITLE
Change the implementation of PromiseXS::Promise::all to that of Promises::collect

### DIFF
--- a/t/promise_all_race.t
+++ b/t/promise_all_race.t
@@ -23,6 +23,20 @@ $p1->all($p1, $p2)->then( sub {
     );
 } );
 
+$p1->all($p1, 'bar')->then( sub {
+    my (@got)  = @_;
+
+    is_deeply(
+        \@got,
+        [
+            [ 2, 3 ],
+            [ 'bar' ],
+        ],
+        'all() works as a method of the promise object and string',
+    );
+} );
+
+
 Promise::XS::Promise->all($p1, $p2)->then( sub {
     my (@got)  = @_;
 


### PR DESCRIPTION
Promises, Perl's Promise implementation, returns an ArrayRef when a non-Promise value is put in the collect.
https://metacpan.org/pod/Promises#collect(-@promises-)

However, Promise::XS returns an error.

Promise::XS is compatible with Promise, so I hope it works the same.