### PR TITLE
Fix: Modernize Perl test matrix and optimize CI environment

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -194,24 +194,17 @@ jobs:
         run: docker run --rm --interactive --platform ${{ matrix.docker_platform }} --mount type=bind,source=$(pwd),target=/host ${{ matrix.platform }}/alpine sh -c "apk add wget perl-app-cpanminus perl-dev make gcc libc-dev; cd /host; perl -V; cpanm --verbose --notest --installdeps --with-configure --with-develop .; perl Makefile.PL; make -j3 -j3; PERL_DL_NONLAZY=1 prove -wlvmb t"
 
   BSDs:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         os:
           - name: freebsd
-            version: '13.1'
+            version: '15.0'
             pkginstall: pkg install -y git p5-ExtUtils-MakeMaker
-        # Breaking due to some weird linker error ...
-        #  - name: freebsd
-        #    version: '12.2'
-        #    pkginstall: pkg install -y git cmake p5-ExtUtils-MakeMaker
           - name: openbsd
-            version: '7.2'
-            pkginstall: pkg_add git curl p5-ExtUtils-MakeMaker
-          - name: openbsd
-            version: '6.9'
+            version: '7.8'
             pkginstall: pkg_add git curl p5-ExtUtils-MakeMaker
 
     steps:

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -27,7 +27,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: Install Dependencies
-        run: cpanm --notest --installdeps --with-configure --with-develop --verbose .
+        run: cpm install -g --verbose --notest --with-all
       - name: perl Makefile.PL
         run: perl Makefile.PL
       - name: make
@@ -42,6 +42,9 @@ jobs:
       fail-fast: false
       matrix:
         perl-version:
+          - '5.42'
+          - '5.40'
+          - '5.38'
           - '5.36'
           - '5.34'
           - '5.32'
@@ -67,7 +70,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: Install Dependencies
-        run: cpanm --notest --installdeps --with-configure --with-develop --verbose .
+        run: cpm install -g --verbose --notest --with-configure --with-develop
       - name: perl Makefile.PL
         run: perl Makefile.PL
       - name: make
@@ -77,19 +80,19 @@ jobs:
 
   linux-debug:
     runs-on: ubuntu-latest
-
+    env:
+       PERL5LIB: ${{ github.workspace }}/local/lib/perl5
     container:
-      image: simcop2387/perl-tester:5.036.000-main-debugging-quadmath-buster
+      image: simcop2387/perl-tester:5.036.000-main-debugging-quadmath-bullseye
 
     steps:
       - uses: actions/checkout@main
         with:
             submodules: recursive
-      - run: apt update && apt install -y curl
       - name: perl -V
         run: perl -V
       - name: Install Dependencies
-        run: curl https://cpanmin.us | perl - --notest --installdeps --with-configure --with-develop --verbose .
+        run: cpm install -L "$GITHUB_WORKSPACE/local" --notest  --with-configure --with-develop -v --show-build-log-on-failure
       - name: perl Makefile.PL
         run: perl Makefile.PL
       - name: make
@@ -104,12 +107,10 @@ jobs:
       - uses: actions/checkout@main
         with:
             submodules: recursive
-      - name: Set up Perl
-        run: brew install cpanminus
       - name: perl -V
         run: perl -V
-      - name: Install Dependencies
-        run: cpanm --verbose --notest --installdeps --with-develop --with-configure .
+      - name: Install Dependencies 
+        run: curl -fsSL https://raw.githubusercontent.com/skaji/cpm/main/cpm | sudo perl - install -g --with-configure --with-develop --with-recommends
       - name: perl Makefile.PL
         run: perl Makefile.PL
       - name: make
@@ -118,7 +119,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -L https://cpanmin.us | perl - --notest Devel::Cover::Report::Coveralls
+          curl -fsSL https://raw.githubusercontent.com/skaji/cpm/main/cpm | sudo perl - install -g --notest Devel::Cover::Report::Coveralls
           `perl -MConfig -E'print $Config::Config{"sitebin"}'`/cover -test -report Coveralls -ignore_re easyxs
 
   windows:
@@ -138,7 +139,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: Install Dependencies
-        run: curl -L https://cpanmin.us | perl - --notest --installdeps --with-develop --with-configure --verbose .
+        run: curl -fsSL https://raw.githubusercontent.com/skaji/cpm/main/cpm | perl - install -g --with-configure --with-develop
       - name: perl Makefile.PL
         run: perl Makefile.PL
       - name: make
@@ -151,21 +152,19 @@ jobs:
 
     steps:
       - name: Set up Cygwin
-        uses: cygwin/cygwin-install-action@master
+        uses: egor-tensin/setup-cygwin@master
         with:
-            packages: perl_base perl-ExtUtils-MakeMaker make gcc-g++ libcrypt-devel libnsl-devel bash
+            packages: perl perl-ExtUtils-MakeMaker make gcc-g++ libcrypt-devel libnsl-devel bash curl
       - uses: actions/checkout@main
         with:
             submodules: recursive
-      - shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+      - shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
         run: |
-            perl -V
-            cpan -T App::cpanminus
-            cd $GITHUB_WORKSPACE
-            cpanm --verbose --notest --installdeps --with-configure --with-develop .
-            perl Makefile.PL
-            make
-            prove -wlvmb t
+           curl -fsSL https://raw.githubusercontent.com/skaji/cpm/main/cpm | perl - install -g App::cpm
+           cd $GITHUB_WORKSPACE
+           cpm install -g --verbose --notest --with-configure --with-recommends
+           perl Makefile.PL
+           make test
 
   qemu-alpine:
     runs-on: ubuntu-latest
@@ -173,12 +172,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - i386
-          - arm32v6
-          - arm32v7
-          - arm64v8
-          - s390x
+        include:
+          - platform: i386
+            docker_platform: linux/386
+          - platform: arm32v6
+            docker_platform: linux/arm/v6
+          - platform: arm32v7
+            docker_platform: linux/arm/v7
+          - platform: arm64v8
+            docker_platform: linux/arm64
+          - platform: s390x
+            docker_platform: linux/s390x
 
     steps:
       - uses: actions/checkout@main
@@ -187,7 +191,7 @@ jobs:
       - name: Get the qemu container
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Run tests on ${{ matrix.platform }}
-        run: docker run --rm --interactive --mount type=bind,source=$(pwd),target=/host ${{ matrix.platform }}/alpine sh -c "apk add wget perl-app-cpanminus perl-dev make gcc libc-dev; cd /host; perl -V; cpanm --verbose --notest --installdeps --with-configure --with-develop .; perl Makefile.PL; make -j3 -j3; PERL_DL_NONLAZY=1 prove -wlvmb t"
+        run: docker run --rm --interactive --platform ${{ matrix.docker_platform }} --mount type=bind,source=$(pwd),target=/host ${{ matrix.platform }}/alpine sh -c "apk add wget perl-app-cpanminus perl-dev make gcc libc-dev; cd /host; perl -V; cpanm --verbose --notest --installdeps --with-configure --with-develop .; perl Makefile.PL; make -j3 -j3; PERL_DL_NONLAZY=1 prove -wlvmb t"
 
   BSDs:
     runs-on: macos-10.15
@@ -223,7 +227,7 @@ jobs:
           shell: bash
           run: |
             sudo ${{ matrix.os.pkginstall }}
-            curl -L https://cpanmin.us | sudo perl - --verbose --notest --installdeps --with-configure --with-develop .
+            curl -fsSL https://raw.githubusercontent.com/skaji/cpm/main/cpm | sudo perl - install -g --with-configure --with-develop --with-recommends
             perl Makefile.PL
             make
             prove -wlvmb t

--- a/cpanfile
+++ b/cpanfile
@@ -6,6 +6,6 @@ test_requires 'Test::FailWarnings', 0;
 test_requires 'File::Temp', 0;
 
 author_requires 'AnyEvent';
-author_requires 'IO::Async';
+$^V ge v5.14.0 && author_requires 'IO::Async';
 $^V ge v5.16.0 && author_requires 'Mojolicious';
 $^V ge v5.16.0 && author_requires 'Future::AsyncAwait';


### PR DESCRIPTION
This PR fixes several environment-related issues and modernizes the Perl test suite to ensure better compatibility and performance.

### Changes

* **Add: Modernize supported Perl versions**
  * Add moderinize Perl versions

* **Fix: Switch from `cpanm` to `cpm` for faster installation**
  * Replaced `cpanm` with **`cpm`** to address slow dependency installation. This significantly improves CI build times.

* **Fix: Upgrade `simcop2387/perl-tester` to Bullseye**
  * Updated the base environment of `simcop2387/perl-tester` to **Debian Bullseye** to fix issues stemming from outdated system packages.

* **Fix: Clean up Cygwin environment**
  * Refactored and organized the Cygwin setup to remove redundant configurations and ensure a more stable build environment.
